### PR TITLE
Vagrant specification for a standalone MusicBrainz-Server dev instance

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cookbooks"]
+	path = cookbooks
+	url = git://github.com/metabrainz/chef-cookbooks.git

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# MusicBrainz Vagrant Images

--- a/musicbrainz-server/.gitignore
+++ b/musicbrainz-server/.gitignore
@@ -1,0 +1,2 @@
+musicbrainz-db.vmdk
+data/

--- a/musicbrainz-server/README.md
+++ b/musicbrainz-server/README.md
@@ -1,0 +1,57 @@
+# Building Your Own Virtual Machine
+
+## Prerequisites
+
+* Git
+* [VirtualBox](https://www.virtualbox.org/)
+* [Vagrant](http://vagrantup.com/)
+
+This brief tutorial assumes that you have nothing listening on ports 2222 or
+5000 before starting.
+
+## Building a Virtual Machine
+
+1. Clone this repository:
+
+        git clone --recursive git://github.com/metabrainz/vagrant-images.git
+
+2. Change to the cloned `musicbrainz-server` directory:
+
+        cd vagrant-images/musicbrainz-server
+
+3. Bring up the virtual machine:
+
+        vagrant up
+
+4. Wait while Chef provisions the virtual machine correctly.
+
+SSH is running on this virtual machine on port 2222. You can login as user
+`vagrant`, password `vagrant`. You may find it more convenient to simply run
+`vagrant ssh`. musicbrainz-server is checked out as the `musicbrainz` user in
+the `/home/musicbrainz/musicbrainz-server` directory.
+
+The database is served by PostgreSQL, listening on port 5432 in the virtual
+machine. This is not currently forwarded outside the virtual machine.
+
+Once step 4 completes, you should have a functioning
+[musicbrainz-server](http://github.com/metabrainz/musicbrainz-server.git). The
+server itself is listening on port 5000. However, before you can use it
+you will need add some data:
+
+## Importing Data
+
+The virtual machine database will initially be devoid of data; it is up to you
+to import data. To import data, you can use the `admin/import-db.sh` script,
+which assumes the following binaries are on your `PATH`:
+
+* wget
+* md5sum
+
+Once you have verified these dependencies are installed, run:
+
+    bash ./admin/import-db.sh
+
+This script will download the latest database dumps to the `data` directory. If
+files already exist here, you will be prompted to delete them, which you are
+sugggested to do unless you know what you are doing. The script will then remove
+any existing musicbrainz database, and import the new data.

--- a/musicbrainz-server/Vagrantfile
+++ b/musicbrainz-server/Vagrantfile
@@ -1,0 +1,44 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "precise32"
+  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+
+  config.vm.provider :vmware_fusion do |v, override|
+    override.vm.box_url = "http://files.vagrantup.com/precise64_vmware.box"
+    override.vm.box = "precise64_vmware.box"
+  end
+
+  config.vm.network :forwarded_port, guest: 5000, host: 5000
+
+  config.vm.provision :chef_solo do |chef|
+    chef.cookbooks_path = "../cookbooks"
+
+    chef.json = {
+      "musicbrainz-server" => {
+        :revision => "vagrant",
+        :dbdefs => {
+          :catalyst_debug => false,
+          :development_server => true,
+          :databases => {
+            :READWRITE => {
+              :database => "musicbrainz",
+              :username => "musicbrainz",
+              :schema => "musicbrainz"
+            },
+            :SYSTEM => {
+              :database => 'template1',
+              :username => 'postgres'
+            }
+          },
+          :db_schema_sequence => 18
+        }
+      }
+    }
+
+    chef.add_recipe "apt"
+    chef.add_recipe "redis"
+    chef.add_recipe "postgresql"
+    chef.add_recipe "memcached"
+    chef.add_recipe "musicbrainz-server::dev"
+    chef.add_recipe "musicbrainz-server::slave"
+  end
+end

--- a/musicbrainz-server/admin/guest/run-import.sh
+++ b/musicbrainz-server/admin/guest/run-import.sh
@@ -1,0 +1,8 @@
+#!bash
+if (psql -U postgres -Atc "SELECT datname FROM pg_database" | grep -q musicbrainz)
+then
+    dropdb -U postgres musicbrainz
+fi
+
+perl /home/musicbrainz/musicbrainz-server/admin/InitDb.pl --createdb \
+  --import /vagrant/data/mbdump*.tar.bz2

--- a/musicbrainz-server/admin/import-db.sh
+++ b/musicbrainz-server/admin/import-db.sh
@@ -1,0 +1,39 @@
+#!bash
+cd $(dirname $0)/..
+
+mkdir -p data
+pushd data
+rm -i *
+
+set -e
+
+function require {
+  which $1 >/dev/null 2>&1 || (
+    echo "$1" is required but could not be found
+    exit 1
+  )
+}
+
+MD5SUM=md5sum
+CURL=curl
+VAGRANT=vagrant
+
+require $MD5SUM $CURL $VAGRANT
+
+echo `date`: Fetching LATEST mbdump files
+LATEST=$($CURL -s ftp://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport/LATEST)
+for f in MD5SUMS mbdump{,-cover-art-archive,-derived,-documentation,-editor,-stats,-wikidocs}.tar.bz2
+do
+    echo `date`: Fetching "$f"
+    test -e "$f" || \
+        $CURL "ftp://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport/$LATEST/$f" \
+            -o "$f"
+done
+
+$MD5SUM -c MD5SUMS
+
+echo `date`: Running import on guest
+popd
+
+$VAGRANT up
+$VAGRANT ssh -c "bash /vagrant/admin/guest/run-import.sh"


### PR DESCRIPTION
The musicbrainz-server/Vagrantfile is able to bring up a Ubuntu Precise
virtual machine up, which has been provisioned to run PostgreSQL, memcached,
Redis and MusicBrainz-Server.

Also, admin/import-db.sh will import the LATEST mbdump*.tar.bz2 archives into
the virtual machine. Thus from a fresh checkout, just running
admin/import-db.sh will import the virtual machine, provision it and import
data.
